### PR TITLE
Fix typeahead and search for phone numbers.

### DIFF
--- a/frontend/src/api/Search.js
+++ b/frontend/src/api/Search.js
@@ -32,11 +32,14 @@ export default {
    * @param {String} value - search value.
    * @returns {Array} a list of employees matching the query.
    */
-  employees (key, value, org) {
+  employees (key, value, org, exactSearch = true) {
     key = key || '*'
     value = value || '*'
     org = org || '*'
-    return Service.get(`/employees/select?fq=${key}:"${value}" AND root_uuid:"${org}"&rows=100000&q=*:*`)
+    if (!exactSearch) {
+      value += '*'
+    }
+    return Service.get(`/employees/select?fq=${key}:${value} AND root_uuid:"${org}"&rows=100000&q=*:*`)
       .then(response => {
         return parseAndSortResponseData(response)
       })
@@ -51,11 +54,14 @@ export default {
    * @param {String} value - search value.
    * @returns {Array} a list of departments matching the query.
    */
-  departments (key, value, org) {
+  departments (key, value, org, exactSearch = true) {
     key = key || '*'
     value = value || '*'
     org = org || '*'
-    return Service.get(`/departments/select?fq=${key}:"${value}" AND root_uuid:"${org}"&rows=100000&q=*:*`)
+    if (!exactSearch) {
+      value += '*'
+    }
+    return Service.get(`/departments/select?fq=${key}:${value} AND root_uuid:"${org}"&rows=100000&q=*:*`)
       .then(response => {
         return parseAndSortResponseData(response)
       })

--- a/frontend/src/api/SearchMultipleFields.js
+++ b/frontend/src/api/SearchMultipleFields.js
@@ -4,15 +4,15 @@ import Search from '@/api/Search'
  * Search employees and departments for the term specified by 'searchTerm' (string),
  * in the fields specified by searchFields (array)
  */
-function SearchMultipleFields (searchTerm = '*', searchFields = ['*'], organisation) {
+function SearchMultipleFields (searchTerm = '*', searchFields = ['*'], organisation, exact = false) {
   let searchResults = []
 
   searchFields.forEach(field => {
-    const employeeSearch = Search.employees(field, searchTerm, organisation)
+    const employeeSearch = Search.employees(field, searchTerm, organisation, exact)
       .then(response => {
         return response
       })
-    const departmentSearch = Search.departments(field, searchTerm, organisation)
+    const departmentSearch = Search.departments(field, searchTerm, organisation, exact)
       .then(response => {
         return response
       })


### PR DESCRIPTION

When searching for persons, departments and phone numbers, we now use wildcards to match partial string - e.g., the search string "Pet" matches people called "Peter" or "Petersen".